### PR TITLE
chore: add MIT license and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Storm Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,35 @@ Opening this repository in **[Cursor](https://cursor.sh)** automatically starts 
    * **Anvil** – local Ethereum node (`anvil -p 8545`)
    * **Foundry Tests** – executes `forge test -vvv`
 
+## 🔧 Configuration & Build-time Arguments
+
+The `dev-env/Dockerfile` is designed to be **highly configurable at build time**. The most common tweaks can be achieved by supplying `--build-arg` flags—no patching of the Dockerfile required.
+
+| ARG | Default | Purpose |
+|-----|---------|---------|
+| `RUNTIME_BASE` | `ubuntu:24.04` | Base OS for the final runtime layer. Swap to `debian:bookworm-slim`, Alpine, etc. |
+| `FOUNDRY_VERSION` | `latest` | Upstream [`foundry-rs/foundry`](https://github.com/foundry-rs/foundry) image tag (e.g. `nightly`, `v1.0.0`). |
+| `NODE_VERSION` | `22.4.0` | Node.js version installed via `pnpm env use -g`. |
+| `RUST_VERSION` | `1.77.1` | Rust tool-chain version managed by `rustup`. |
+| `USERNAME` | `dev` | Non-root user created inside both build and runtime layers. |
+
+Example: build the image against the **nightly Foundry** release and a newer Node.js version:
+
+```bash
+docker build \
+  --build-arg FOUNDRY_VERSION=nightly \
+  --build-arg NODE_VERSION=22.6.0 \
+  -t ghcr.io/storm-labs/dev-env:nightly \
+  -f dev-env/Dockerfile .
+```
+
+The resulting image preserves all other defaults (Python 3.12, `uv`, offline docs, etc.) while pulling in your custom tooling versions.
+
 ## 🧰 just Recipes
 
 | Recipe | Description |
 |--------|-------------|
-| `just build` | Build the dev image and tag it as `:local` (both `ghcr.io/storm-labs/**` and `storm-labs/**`). |
+| `just build` | Build the dev image and tag it as \`:local\` (both \`ghcr.io/storm-labs/**\` and \`storm-labs/**\`). |
 | `just lint` | Lint the Dockerfile with [hadolint](https://github.com/hadolint/hadolint). |
 | `just dev-install` | Hook executed by Cursor to install extra dependencies (currently does nothing). |
 | `just` | List all available recipes. |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A GitHub Actions workflow (`.github/workflows/publish-image.yml`) automatically 
 * **`dev-env/Dockerfile`** – Multi-stage build producing a stripped-down runtime image.
 * **`.cursor/environment.json`** – Instructions for Cursor-based dev-containers.
 * **`justfile`** – Helper scripts for building, linting, and future automation.
+* **`.github/workflows/publish-image.yml`** – CI workflow that builds & publishes the multi-arch dev image to GHCR on every `master` commit and semantic tag.
 * **`.github/workflows/update-docs.yml`** – Weekly cron that refreshes the offline documentation cache.
 
 ## 📚 Offline Documentation
@@ -80,3 +81,7 @@ The container now ships with an **offline mirror** of the following documentatio
 At runtime the mirror is mounted at `$DOCS_HOME` (`/usr/share/docs`). Open any `index.html` inside that directory to browse completely offline—perfect for flights, air-gapped CI, or when the public sites go down.
 
 The mirror is refreshed weekly by the `update-docs.yml` workflow so it's always up-to-date without manual intervention.
+
+## 📝 License
+
+This project is licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
Add MIT license and update README.md to reflect recent workflow and Dockerfile changes.