### PR TITLE
Fix Python and streamline `uv` installations in Docker builder stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A self-contained Docker image that bundles the complete tool-chain required for 
 |-----------|---------|
 | Blockchain | Foundry (`forge`, `cast`, `anvil`) |
 | JavaScript | Node.js 22 (22.4.0), `pnpm` |
-| Python     | Python 3.12, [`pipx`](https://pypa.github.io/pipx), [`uv`](https://github.com/astral-sh/uv) |
+| Python     | Python 3.13, [`uv`](https://github.com/astral-sh/uv) |
 | Rust       | `rustup` + stable tool-chain |
 | Utilities  | `git`, `curl`, `build-essential`, many more |
 
@@ -26,7 +26,7 @@ docker pull ghcr.io/storm-labs/dev-env:latest
 just build
 
 # 2. Open an ephemeral shell inside the container
-docker run -it --rm ghcr.io/storm-labs/dev-env:local
+docker run -it --rm ghcr.io/storm-labs/dev-env:local bash
 ```
 
 Once inside you'll have access to the full tool-chain, e.g.
@@ -34,7 +34,8 @@ Once inside you'll have access to the full tool-chain, e.g.
 ```bash
 forge --version
 node -v
-python3.12 -m uv --version
+python3 --version
+uv --version
 ```
 
 ## 🐭 Quick-start (Cursor)
@@ -68,7 +69,7 @@ docker build \
   -f dev-env/Dockerfile .
 ```
 
-The resulting image preserves all other defaults (Python 3.12, `uv`, offline docs, etc.) while pulling in your custom tooling versions.
+The resulting image preserves all other defaults (Python 3.13, `uv`, offline docs, etc.) while pulling in your custom tooling versions.
 
 ## 🧰 just Recipes
 

--- a/dev-env/Dockerfile
+++ b/dev-env/Dockerfile
@@ -53,16 +53,15 @@ RUN curl -fsSL https://get.pnpm.io/install.sh | bash -s -- && \
     rustup default "${RUST_VERSION}"
 
 # --------------------------
-# 3. Python 3.12 (from Noble) + pipx + uv
+# 3. Python 3.13 + uv
 # --------------------------
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends python3.12 python3.12-venv && \
-    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \
-    python3.12 -m pip install --no-cache-dir pipx==1.7.1 && \
-    pipx install uv==0.7.18 && \
+    apt-get install -y --no-install-recommends python3.13 && \
+    apt-get install -y libexpat1 && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     rm -rf /var/lib/apt/lists/*
 
 # Switch to non-root user in builder stage for safer defaults
@@ -89,6 +88,14 @@ COPY --from=builder /usr/local /usr/local
 COPY --from=builder /root/.local /home/${USERNAME}/.local
 COPY --from=builder /root/.cargo /root/.cargo
 COPY --from=builder /root/.rustup /root/.rustup
+# Copy Python binary and libraries
+# TODO: Consider moving Python to the Runtime layer to avoid arch mismatch
+COPY --from=builder /usr/bin/python3.13 /usr/bin/python3.13
+COPY --from=builder /usr/lib/python3.13 /usr/lib/python3.13
+COPY --from=builder /usr/lib/python3.13/ /usr/lib/python3.13/
+COPY --from=builder /lib/aarch64-linux-gnu/libexpat.so.1 /lib/aarch64-linux-gnu/libexpat.so.1
+
+RUN ln -s /usr/bin/python3.13 /usr/bin/python3
 
 ENV PNPM_HOME="/home/${USERNAME}/.local/share/pnpm"
 ENV PATH="$PNPM_HOME:/home/${USERNAME}/.local/bin:/usr/local/bin:/root/.cargo/bin:${PATH}" \

--- a/dev-env/Dockerfile
+++ b/dev-env/Dockerfile
@@ -60,7 +60,6 @@ RUN apt-get update -y && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends python3.13 && \
-    apt-get install -y libexpat1 && \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     rm -rf /var/lib/apt/lists/*
 
@@ -89,13 +88,11 @@ COPY --from=builder /root/.local /home/${USERNAME}/.local
 COPY --from=builder /root/.cargo /root/.cargo
 COPY --from=builder /root/.rustup /root/.rustup
 # Copy Python binary and libraries
-# TODO: Consider moving Python to the Runtime layer to avoid arch mismatch
 COPY --from=builder /usr/bin/python3.13 /usr/bin/python3.13
 COPY --from=builder /usr/lib/python3.13 /usr/lib/python3.13
-COPY --from=builder /usr/lib/python3.13/ /usr/lib/python3.13/
-COPY --from=builder /lib/aarch64-linux-gnu/libexpat.so.1 /lib/aarch64-linux-gnu/libexpat.so.1
 
 RUN ln -s /usr/bin/python3.13 /usr/bin/python3
+RUN ln -s /usr/bin/python3.13 /usr/bin/python
 
 ENV PNPM_HOME="/home/${USERNAME}/.local/share/pnpm"
 ENV PATH="$PNPM_HOME:/home/${USERNAME}/.local/bin:/usr/local/bin:/root/.cargo/bin:${PATH}" \
@@ -108,6 +105,7 @@ ENV DOCS_HOME="/usr/share/docs"
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get install -y --no-install-recommends libexpat1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for safer defaults (configurable)


### PR DESCRIPTION
- Fix Python installation + move to 3.13 from deadsnakes
- Streamline `uv` setup, drop `pip`, `venv` and `pipx`
- Update README accordingly